### PR TITLE
Add Docker Compose, onboarding welcome page, and env fixes

### DIFF
--- a/backend/.env.docker
+++ b/backend/.env.docker
@@ -1,0 +1,6 @@
+DATABASE_URL=postgresql://postgres:postgres@postgres:5432/coparent
+SECRET_KEY=dev-secret-key-change-in-production
+ANTHROPIC_API_KEY=your-anthropic-api-key
+CLERK_SECRET_KEY=sk_test_drxniWmtptsVTXcnhXhFlO7pieuvqyQWsg74nQwb4g
+CLERK_PUBLISHABLE_KEY=pk_test_ZW5vdWdoLW1hbGFtdXRlLTM4LmNsZXJrLmFjY291bnRzLmRldiQ
+LOCAL_DEV=true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,65 @@
+services:
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: coparent
+    ports:
+      - "5434:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    networks:
+      - default
+      - traefik-proxy
+
+  backend:
+    image: ghcr.io/astral-sh/uv:python3.12-bookworm-slim
+    working_dir: /app
+    command: uv run uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
+    volumes:
+      - ./backend:/app
+    env_file:
+      - path: ./backend/.env.docker
+        required: false
+    depends_on:
+      - postgres
+    networks:
+      - default
+      - traefik-proxy
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.coparent-api.rule=Host(`coparent.localhost`) && PathPrefix(`/api`)"
+      - "traefik.http.routers.coparent-api.priority=200"
+      - "traefik.http.routers.coparent-api.entrypoints=web"
+      - "traefik.http.services.coparent-api.loadbalancer.server.port=8000"
+
+  frontend:
+    image: node:20-slim
+    working_dir: /app
+    command: sh -c "npm install && npm run dev -- --host 0.0.0.0"
+    volumes:
+      - ./frontend:/app
+      - frontend_node_modules:/app/node_modules
+    environment:
+      - VITE_CLERK_PUBLISHABLE_KEY=${VITE_CLERK_PUBLISHABLE_KEY:-pk_test_ZW5vdWdoLW1hbGFtdXRlLTM4LmNsZXJrLmFjY291bnRzLmRldiQ}
+      - VITE_LOCAL_DEV=true
+    depends_on:
+      - backend
+    networks:
+      - default
+      - traefik-proxy
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.coparent-frontend.rule=Host(`coparent.localhost`)"
+      - "traefik.http.routers.coparent-frontend.priority=100"
+      - "traefik.http.routers.coparent-frontend.entrypoints=web"
+      - "traefik.http.services.coparent-frontend.loadbalancer.server.port=5173"
+
+volumes:
+  pgdata:
+  frontend_node_modules:
+
+networks:
+  traefik-proxy:
+    external: true

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -6,6 +6,7 @@ import ChallengeCard from '../components/ChallengeCard';
 import CreateChallengeModal from '../components/CreateChallengeModal';
 import TeamSetup from '../components/TeamSetup';
 import TeamSettingsModal from '../components/TeamSettingsModal';
+import WelcomePage from './WelcomePage';
 
 interface Props {
   user: User;
@@ -19,6 +20,7 @@ export default function DashboardPage({ user, onDevSignOut }: Props) {
   const [team, setTeam] = useState<Team | null>(null);
   const [teamLoading, setTeamLoading] = useState(true);
   const [showTeamSettings, setShowTeamSettings] = useState(false);
+  const [skippedOnboarding, setSkippedOnboarding] = useState(false);
 
   const fetchChallenges = async () => {
     try {
@@ -53,6 +55,16 @@ export default function DashboardPage({ user, onDevSignOut }: Props) {
       // ignore
     }
   };
+
+  // Show full-screen welcome for first-time users (no team yet)
+  if (!teamLoading && !team && !skippedOnboarding) {
+    return (
+      <WelcomePage
+        onComplete={(t) => setTeam(t)}
+        onSkip={() => setSkippedOnboarding(true)}
+      />
+    );
+  }
 
   return (
     <div className="min-h-screen bg-slate-50">

--- a/frontend/src/pages/WelcomePage.tsx
+++ b/frontend/src/pages/WelcomePage.tsx
@@ -1,0 +1,97 @@
+import { useState } from 'react';
+import TeamSetup from '../components/TeamSetup';
+import type { Team } from '../types';
+
+interface Props {
+  onComplete: (team: Team) => void;
+  onSkip: () => void;
+}
+
+const steps = [
+  {
+    number: '1',
+    title: 'Define the Challenge',
+    description: 'Describe what your team needs to work through. Everyone reviews and approves the problem statement before moving on.',
+    color: 'bg-emerald-100 text-emerald-700',
+  },
+  {
+    number: '2',
+    title: 'Brainstorm Ideas',
+    description: 'Each teammate contributes ideas independently. Keep private draft notes while you think things through.',
+    color: 'bg-sky-100 text-sky-700',
+  },
+  {
+    number: '3',
+    title: 'AI-Powered Analysis',
+    description: 'When everyone is ready, AI analyzes every idea for pros/cons, feasibility, and fairness — so decisions are balanced.',
+    color: 'bg-amber-100 text-amber-700',
+  },
+];
+
+export default function WelcomePage({ onComplete, onSkip }: Props) {
+  const [showSetup, setShowSetup] = useState(false);
+
+  if (showSetup) {
+    return (
+      <div className="min-h-screen bg-slate-50 flex items-center justify-center px-4">
+        <div className="max-w-lg w-full">
+          <TeamSetup onTeamCreated={onComplete} />
+          <button
+            onClick={onSkip}
+            className="mt-2 w-full text-center text-sm text-slate-500 hover:text-slate-700"
+          >
+            I'll do this later
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-slate-50 flex items-center justify-center px-4">
+      <div className="max-w-2xl w-full py-12">
+        {/* Welcome header */}
+        <div className="text-center mb-10">
+          <h1 className="text-3xl font-bold text-slate-900 tracking-tight">Welcome to Greenlight</h1>
+          <p className="mt-3 text-lg text-slate-600">
+            A structured space for teams to work through decisions together — fairly, calmly, and with AI support.
+          </p>
+        </div>
+
+        {/* How it works */}
+        <div className="bg-white rounded-lg border border-slate-200/60 shadow-sm p-6 mb-8">
+          <h2 className="text-sm font-semibold text-slate-500 uppercase tracking-wide mb-5">How it works</h2>
+          <div className="space-y-5">
+            {steps.map((step) => (
+              <div key={step.number} className="flex items-start gap-4">
+                <div className={`flex-shrink-0 w-8 h-8 rounded-full flex items-center justify-center font-bold text-sm ${step.color}`}>
+                  {step.number}
+                </div>
+                <div>
+                  <h3 className="font-semibold text-slate-900">{step.title}</h3>
+                  <p className="text-sm text-slate-600 mt-0.5">{step.description}</p>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Actions */}
+        <div className="flex flex-col items-center gap-3">
+          <button
+            onClick={() => setShowSetup(true)}
+            className="w-full max-w-sm px-6 py-3 bg-emerald-600 text-white rounded-md hover:bg-emerald-700 font-semibold text-center shadow-sm transition-colors"
+          >
+            Get Started
+          </button>
+          <button
+            onClick={onSkip}
+            className="text-sm text-slate-500 hover:text-slate-700"
+          >
+            Skip — I'll explore on my own
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- **Docker Compose**: Self-contained local dev with Traefik path-based routing (`/api/*` → backend, `/*` → frontend), Postgres, and `VITE_LOCAL_DEV=true` for dev user picker
- **Onboarding**: Full-screen `WelcomePage` for first-time users with how-it-works steps (Define → Brainstorm → AI Analysis) flowing into GroupSetup
- **Env vars**: Set `ANTHROPIC_API_KEY` and `RESEND_API_KEY` in Doppler + Cloud Run

## Test plan
- [ ] `docker compose up` → `coparent.localhost` loads frontend, `/api/health` returns ok
- [ ] Dev user picker appears (VITE_LOCAL_DEV=true)
- [ ] New user with no group sees WelcomePage → Get Started → GroupSetup flow
- [ ] Skip option falls back to dashboard with inline GroupSetup card
- [ ] Existing user with group goes straight to dashboard

Closes #23, #20, #18, #19, #21, #1, #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)