### PR TITLE
Mobile responsiveness polish and cleanup

### DIFF
--- a/backend/.env.docker
+++ b/backend/.env.docker
@@ -3,4 +3,3 @@ SECRET_KEY=dev-secret-key-change-in-production
 ANTHROPIC_API_KEY=your-anthropic-api-key
 CLERK_SECRET_KEY=sk_test_drxniWmtptsVTXcnhXhFlO7pieuvqyQWsg74nQwb4g
 CLERK_PUBLISHABLE_KEY=pk_test_ZW5vdWdoLW1hbGFtdXRlLTM4LmNsZXJrLmFjY291bnRzLmRldiQ
-LOCAL_DEV=true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,6 @@ services:
       - frontend_node_modules:/app/node_modules
     environment:
       - VITE_CLERK_PUBLISHABLE_KEY=${VITE_CLERK_PUBLISHABLE_KEY:-pk_test_ZW5vdWdoLW1hbGFtdXRlLTM4LmNsZXJrLmFjY291bnRzLmRldiQ}
-      - VITE_LOCAL_DEV=true
     depends_on:
       - backend
     networks:

--- a/frontend/src/components/AnalysisPanel.tsx
+++ b/frontend/src/components/AnalysisPanel.tsx
@@ -76,19 +76,17 @@ export default function AnalysisPanel({ idea }: Props) {
     <div className="bg-white border border-slate-200/60 rounded-lg shadow-sm overflow-hidden">
       <button
         onClick={() => setExpanded(!expanded)}
-        className="w-full px-4 py-3 flex items-center justify-between hover:bg-slate-50 transition-colors"
+        className="w-full px-4 py-3 flex items-start sm:items-center justify-between gap-2 hover:bg-slate-50 transition-colors"
       >
-        <div className="flex items-center gap-3">
-          <span className="text-slate-800 font-medium text-left">{idea.content}</span>
-        </div>
-        <div className="flex items-center gap-2">
+        <span className="text-slate-800 font-medium text-left flex-1">{idea.content}</span>
+        <div className="flex items-center gap-2 shrink-0">
           {feasibilityData && (
-            <span className="text-xs px-2 py-1 bg-sky-50 text-sky-700 rounded">
+            <span className="hidden sm:inline text-xs px-2 py-1 bg-sky-50 text-sky-700 rounded">
               Feasibility: {feasibilityData.score}/10
             </span>
           )}
           {impactData && (
-            <span className="text-xs px-2 py-1 bg-indigo-50 text-indigo-700 rounded">
+            <span className="hidden sm:inline text-xs px-2 py-1 bg-indigo-50 text-indigo-700 rounded">
               Impact: {impactData.score}/10
             </span>
           )}

--- a/frontend/src/components/CreateChallengeModal.tsx
+++ b/frontend/src/components/CreateChallengeModal.tsx
@@ -33,8 +33,8 @@ export default function CreateChallengeModal({ groupId, onCreated, onClose }: Pr
   };
 
   return (
-    <div className="fixed inset-0 bg-slate-900/60 flex items-center justify-center z-50 p-4">
-      <div className="bg-white rounded-xl shadow-xl border border-slate-200/60 max-w-lg w-full p-6">
+    <div className="fixed inset-0 bg-slate-900/60 flex items-end sm:items-center justify-center z-50 p-0 sm:p-4">
+      <div className="bg-white rounded-t-xl sm:rounded-xl shadow-xl border border-slate-200/60 max-w-lg w-full p-5 sm:p-6 max-h-[90vh] overflow-y-auto">
         <h2 className="text-xl font-semibold text-slate-900 mb-4">New Challenge</h2>
         <form onSubmit={handleSubmit} className="space-y-4">
           {error && (

--- a/frontend/src/components/SessionStatusBar.tsx
+++ b/frontend/src/components/SessionStatusBar.tsx
@@ -60,8 +60,8 @@ export default function SessionStatusBar({ session, ideaCount, currentUserId, on
         })}
       </div>
 
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-3">
+      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
+        <div className="flex flex-wrap items-center gap-2 sm:gap-3">
           <span className={`px-2.5 py-0.5 rounded-full text-xs font-medium ${status.color}`}>
             {status.label}
           </span>
@@ -74,14 +74,14 @@ export default function SessionStatusBar({ session, ideaCount, currentUserId, on
         </div>
         {isGateable && ideaCount > 0 && (
           currentUserApproved ? (
-            <span className="px-4 py-2 bg-slate-100 text-slate-500 rounded-md text-sm font-medium">
+            <span className="px-4 py-2 bg-slate-100 text-slate-500 rounded-md text-sm font-medium text-center">
               Waiting for team to approve...
             </span>
           ) : (
             <button
               onClick={onApprove}
               disabled={approving}
-              className="px-4 py-2 bg-emerald-600 text-white rounded-md hover:bg-emerald-700 disabled:opacity-50 font-medium shadow-sm transition-colors"
+              className="px-4 py-2.5 bg-emerald-600 text-white rounded-md hover:bg-emerald-700 disabled:opacity-50 font-medium shadow-sm transition-colors"
             >
               {approving ? 'Approving...' : gateButtonText}
             </button>

--- a/frontend/src/components/TeamSettingsModal.tsx
+++ b/frontend/src/components/TeamSettingsModal.tsx
@@ -83,8 +83,8 @@ export default function TeamSettingsModal({ team, onClose, onTeamUpdated }: Prop
   };
 
   return (
-    <div className="fixed inset-0 bg-slate-900/60 flex items-center justify-center z-50 p-4">
-      <div className="bg-white rounded-xl shadow-xl border border-slate-200/60 max-w-md w-full p-6 max-h-[90vh] overflow-y-auto">
+    <div className="fixed inset-0 bg-slate-900/60 flex items-end sm:items-center justify-center z-50 p-0 sm:p-4">
+      <div className="bg-white rounded-t-xl sm:rounded-xl shadow-xl border border-slate-200/60 max-w-md w-full p-5 sm:p-6 max-h-[90vh] overflow-y-auto">
         <div className="flex items-center justify-between mb-5">
           <h2 className="text-lg font-semibold text-slate-900">Team Settings</h2>
           <button onClick={onClose} className="text-slate-400 hover:text-slate-600 text-xl leading-none transition-colors">&times;</button>

--- a/frontend/src/pages/AnalysisPage.tsx
+++ b/frontend/src/pages/AnalysisPage.tsx
@@ -78,15 +78,15 @@ export default function AnalysisPage() {
   return (
     <div className="min-h-screen bg-slate-50">
       <header className="bg-slate-900">
-        <div className="max-w-5xl mx-auto px-4 py-4 flex items-center gap-4">
-          <Link to="/" className="text-slate-400 hover:text-white transition-colors">
-            &larr; Dashboard
+        <div className="max-w-5xl mx-auto px-4 py-4 flex items-center gap-3 sm:gap-4">
+          <Link to="/" className="text-slate-400 hover:text-white transition-colors shrink-0">
+            &larr; <span className="hidden sm:inline">Dashboard</span>
           </Link>
-          <h1 className="text-lg font-semibold text-white tracking-tight">{challenge.title} — Analysis</h1>
+          <h1 className="text-base sm:text-lg font-semibold text-white tracking-tight truncate">{challenge.title} — Analysis</h1>
         </div>
       </header>
 
-      <main className="max-w-5xl mx-auto px-4 py-8 space-y-6">
+      <main className="max-w-5xl mx-auto px-4 py-6 sm:py-8 space-y-4 sm:space-y-6">
         {isInProgress && (
           <AnalysisProgress challengeId={challenge.id} onComplete={reload} />
         )}

--- a/frontend/src/pages/ChallengeDetailPage.tsx
+++ b/frontend/src/pages/ChallengeDetailPage.tsx
@@ -85,16 +85,16 @@ export default function ChallengeDetailPage({ user }: Props) {
   return (
     <div className="min-h-screen bg-slate-50">
       <header className="bg-slate-900">
-        <div className="max-w-5xl mx-auto px-4 py-4 flex items-center gap-4">
-          <Link to="/" className="text-slate-400 hover:text-white transition-colors">&larr; Dashboard</Link>
-          <h1 className="text-lg font-semibold text-white tracking-tight">{challenge.title}</h1>
+        <div className="max-w-5xl mx-auto px-4 py-4 flex items-center gap-3 sm:gap-4">
+          <Link to="/" className="text-slate-400 hover:text-white transition-colors shrink-0">&larr; <span className="hidden sm:inline">Dashboard</span></Link>
+          <h1 className="text-base sm:text-lg font-semibold text-white tracking-tight truncate">{challenge.title}</h1>
         </div>
       </header>
 
-      <main className="max-w-5xl mx-auto px-4 py-8 space-y-6">
+      <main className="max-w-5xl mx-auto px-4 py-6 sm:py-8 space-y-4 sm:space-y-6">
         <div className="bg-white rounded-lg border border-slate-200/60 shadow-sm p-6">
           <p className="text-slate-600">{challenge.description}</p>
-          <form onSubmit={handleAddCollaborator} className="mt-4 flex gap-2 items-end">
+          <form onSubmit={handleAddCollaborator} className="mt-4 flex flex-col sm:flex-row gap-2 sm:items-end">
             <div className="flex-1">
               <label className="block text-xs font-medium text-slate-500 uppercase tracking-wider mb-1">
                 Invite teammate by email

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -71,14 +71,14 @@ export default function DashboardPage({ user, onDevSignOut }: Props) {
       <header className="bg-slate-900">
         <div className="max-w-5xl mx-auto px-4 py-4 flex items-center justify-between">
           <h1 className="text-lg font-semibold text-white tracking-tight">Greenlight</h1>
-          <div className="flex items-center gap-4">
+          <div className="flex items-center gap-2 sm:gap-4">
             {team && (
               <button
                 onClick={() => setShowTeamSettings(true)}
                 className="flex items-center gap-2 px-2 py-1 rounded-md hover:bg-slate-800 transition-colors"
                 title="Team settings"
               >
-                <span className="text-xs text-slate-400 uppercase tracking-wide">{team.name || 'Team'}</span>
+                <span className="hidden sm:inline text-xs text-slate-400 uppercase tracking-wide">{team.name || 'Team'}</span>
                 <div className="flex -space-x-2">
                   {team.members.map((m) => (
                     <div
@@ -92,7 +92,7 @@ export default function DashboardPage({ user, onDevSignOut }: Props) {
                 </div>
               </button>
             )}
-            <span className="text-sm text-slate-300">{user.name}</span>
+            <span className="hidden sm:inline text-sm text-slate-300">{user.name}</span>
             {onDevSignOut ? (
               <button
                 onClick={onDevSignOut}
@@ -107,7 +107,7 @@ export default function DashboardPage({ user, onDevSignOut }: Props) {
         </div>
       </header>
 
-      <main className="max-w-5xl mx-auto px-4 py-8">
+      <main className="max-w-5xl mx-auto px-4 py-6 sm:py-8">
         {!teamLoading && !team && (
           <TeamSetup onTeamCreated={(t) => setTeam(t)} />
         )}


### PR DESCRIPTION
## Summary
- **Mobile responsiveness**: Bottom-sheet modals, stacked forms, hidden labels on small screens, responsive spacing across all pages and components
- **Cleanup**: Remove stale `LOCAL_DEV` / `VITE_LOCAL_DEV` references that were removed during the Greenlight rebrand

## Test plan
- [ ] Resize browser to mobile width — modals slide up from bottom
- [ ] Dashboard header collapses gracefully (user name + team name hidden)
- [ ] Challenge detail invite form stacks vertically on mobile
- [ ] Analysis panel hides score badges on small screens
- [ ] Session status bar wraps to two rows on mobile
- [ ] `docker compose up` still works (no LOCAL_DEV validation error)

Closes #4, #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Improve mobile responsiveness of key UI pages and modals and remove obsolete local development configuration.

New Features:
- Adjust dashboard, analysis, challenge detail layouts, and session status bar to better adapt to small screens, including hiding non-essential text and improving wrapping behavior.
- Update create challenge and team settings modals to behave as bottom sheets on mobile while remaining centered dialogs on larger screens.

Enhancements:
- Refine spacing, truncation, and flex behavior across headers and panels to prevent overflow and improve readability on narrow viewports.

Build:
- Remove unused VITE_LOCAL_DEV environment variable from the frontend service in docker-compose.