### PR TITLE
Add transactional emails and in-app notifications

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -12,6 +12,8 @@ class Settings(BaseSettings):
     production: bool = False
     app_url: str = "http://localhost:5173"
     sentry_dsn: str = ""
+    resend_api_key: str = ""
+    notify_email: str = ""
 
     model_config = {"env_file": ".env"}
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -9,7 +9,7 @@ from fastapi.staticfiles import StaticFiles
 
 from app.config import settings
 from app.database import create_db_and_tables
-from app.routers import auth, challenges, ideas, sessions, ai, analysis, comments, drafts, teams, waitlist
+from app.routers import auth, challenges, ideas, sessions, ai, analysis, comments, drafts, teams, waitlist, notifications
 
 if settings.sentry_dsn:
     sentry_sdk.init(
@@ -46,6 +46,7 @@ app.include_router(comments.router)
 app.include_router(drafts.router)
 app.include_router(teams.router)
 app.include_router(waitlist.router)
+app.include_router(notifications.router)
 
 
 @app.get("/api/health")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -8,6 +8,7 @@ from app.models.approval import SessionApproval
 from app.models.draft import IdeaDraft
 from app.models.group import Team, TeamMember, PendingTeamInvite
 from app.models.waitlist import WaitlistEntry
+from app.models.notification import Notification
 
 __all__ = [
     "User",
@@ -23,4 +24,5 @@ __all__ = [
     "TeamMember",
     "PendingTeamInvite",
     "WaitlistEntry",
+    "Notification",
 ]

--- a/backend/app/models/notification.py
+++ b/backend/app/models/notification.py
@@ -1,0 +1,34 @@
+from datetime import datetime, UTC
+from enum import Enum
+from typing import Optional
+
+from sqlmodel import Field, SQLModel
+
+
+class NotificationType(str, Enum):
+    idea_added = "idea_added"
+    comment_added = "comment_added"
+    approval_changed = "approval_changed"
+    analysis_complete = "analysis_complete"
+    team_invite = "team_invite"
+
+
+class Notification(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    user_id: int = Field(foreign_key="user.id", index=True)
+    type: NotificationType
+    title: str
+    body: str
+    challenge_id: Optional[int] = Field(default=None, foreign_key="challenge.id")
+    read: bool = Field(default=False)
+    created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+
+
+class NotificationRead(SQLModel):
+    id: int
+    type: NotificationType
+    title: str
+    body: str
+    challenge_id: Optional[int]
+    read: bool
+    created_at: datetime

--- a/backend/app/routers/comments.py
+++ b/backend/app/routers/comments.py
@@ -73,4 +73,15 @@ def create_comment(
     session.add(comment)
     session.commit()
     session.refresh(comment)
+
+    from app.services.notifications import notify_collaborators
+    from app.models.notification import NotificationType
+    preview = data.content[:80] + ("..." if len(data.content) > 80 else "")
+    notify_collaborators(
+        session, idea.challenge_id, current_user.id,
+        NotificationType.comment_added,
+        f"{current_user.name} commented",
+        preview,
+    )
+
     return _enrich_comment(comment, session)

--- a/backend/app/routers/ideas.py
+++ b/backend/app/routers/ideas.py
@@ -64,6 +64,17 @@ def create_idea(
     session.add(idea)
     session.commit()
     session.refresh(idea)
+
+    from app.services.notifications import notify_collaborators
+    from app.models.notification import NotificationType
+    preview = data.content[:80] + ("..." if len(data.content) > 80 else "")
+    notify_collaborators(
+        session, challenge_id, current_user.id,
+        NotificationType.idea_added,
+        f"{current_user.name} added an idea",
+        preview,
+    )
+
     return _enrich_idea(idea, session)
 
 

--- a/backend/app/routers/notifications.py
+++ b/backend/app/routers/notifications.py
@@ -1,0 +1,56 @@
+from fastapi import APIRouter, HTTPException
+from sqlmodel import select
+
+from app.database import SessionDep
+from app.dependencies import CurrentUser
+from app.models.notification import Notification, NotificationRead
+
+router = APIRouter(prefix="/api/notifications", tags=["notifications"])
+
+
+@router.get("", response_model=list[NotificationRead])
+def list_notifications(session: SessionDep, current_user: CurrentUser):
+    notifications = session.exec(
+        select(Notification)
+        .where(Notification.user_id == current_user.id)
+        .order_by(Notification.created_at.desc())  # type: ignore
+        .limit(50)
+    ).all()
+    return notifications
+
+
+@router.get("/unread-count")
+def unread_count(session: SessionDep, current_user: CurrentUser):
+    notifications = session.exec(
+        select(Notification).where(
+            Notification.user_id == current_user.id,
+            Notification.read == False,  # noqa: E712
+        )
+    ).all()
+    return {"count": len(notifications)}
+
+
+@router.post("/{notification_id}/read")
+def mark_read(notification_id: int, session: SessionDep, current_user: CurrentUser):
+    notif = session.get(Notification, notification_id)
+    if not notif or notif.user_id != current_user.id:
+        raise HTTPException(status_code=404, detail="Notification not found")
+    notif.read = True
+    session.add(notif)
+    session.commit()
+    return {"message": "Marked as read"}
+
+
+@router.post("/read-all")
+def mark_all_read(session: SessionDep, current_user: CurrentUser):
+    notifications = session.exec(
+        select(Notification).where(
+            Notification.user_id == current_user.id,
+            Notification.read == False,  # noqa: E712
+        )
+    ).all()
+    for n in notifications:
+        n.read = True
+        session.add(n)
+    session.commit()
+    return {"message": f"Marked {len(notifications)} as read"}

--- a/backend/app/routers/sessions.py
+++ b/backend/app/routers/sessions.py
@@ -131,6 +131,16 @@ def approve_session(
     session.add(approval)
     session.commit()
 
+    from app.services.notifications import notify_collaborators
+    from app.models.notification import NotificationType
+    gate_label = "definition" if current_gate == GateType.ideate_to_build else "analysis"
+    notify_collaborators(
+        session, challenge_id, current_user.id,
+        NotificationType.approval_changed,
+        f"{current_user.name} approved",
+        f"Approved moving to the {gate_label} phase",
+    )
+
     # Check if all collaborators have now approved this gate
     total_approvals = len(
         session.exec(

--- a/backend/app/routers/teams.py
+++ b/backend/app/routers/teams.py
@@ -223,6 +223,14 @@ def invite_to_team(
     redirect_url = settings.app_url
     send_clerk_invitation(data.email, redirect_url)
 
+    from app.services.email import send_team_invite_email
+    send_team_invite_email(
+        to_email=data.email,
+        inviter_name=current_user.name,
+        team_name=team.name,
+        app_url=redirect_url,
+    )
+
     session.add(PendingTeamInvite(
         group_id=team_id,
         email=data.email,

--- a/backend/app/routers/waitlist.py
+++ b/backend/app/routers/waitlist.py
@@ -19,6 +19,12 @@ def join_waitlist(data: WaitlistCreate, session: SessionDep):
     session.add(entry)
     session.commit()
     session.refresh(entry)
+
+    from app.services.email import send_waitlist_notification
+    send_waitlist_notification(
+        entry.name, entry.email, entry.created_at.strftime("%B %d, %Y at %I:%M %p UTC"),
+    )
+
     return entry
 
 

--- a/backend/app/services/analysis_runner.py
+++ b/backend/app/services/analysis_runner.py
@@ -8,8 +8,9 @@ from app.ai.summarizer import summarize_session
 from app.database import engine
 from app.models.analysis import Analysis, AnalysisType
 from app.models.idea import Idea
-from app.models.problem import Challenge
+from app.models.problem import Challenge, ChallengeCollaborator
 from app.models.session import GreenlightSession, SessionStatus
+from app.models.user import User
 
 
 def run_analysis(challenge_id: int):
@@ -81,3 +82,38 @@ async def _run_analysis_async(challenge_id: int):
         gs.status = SessionStatus.analysis_complete
         session.add(gs)
         session.commit()
+
+        # Notify collaborators via email + in-app
+        try:
+            from app.config import settings
+            from app.services.email import send_analysis_complete_email
+            from app.models.notification import Notification, NotificationType
+
+            collabs = session.exec(
+                select(ChallengeCollaborator).where(
+                    ChallengeCollaborator.challenge_id == challenge_id
+                )
+            ).all()
+            for collab in collabs:
+                user = session.get(User, collab.user_id)
+                if user:
+                    # In-app notification
+                    session.add(Notification(
+                        user_id=user.id,
+                        type=NotificationType.analysis_complete,
+                        title="Analysis complete",
+                        body=f"AI analysis for \"{challenge.title}\" is ready to review",
+                        challenge_id=challenge_id,
+                    ))
+                    # Email notification
+                    if user.email:
+                        send_analysis_complete_email(
+                            to_email=user.email,
+                            user_name=user.name,
+                            challenge_title=challenge.title,
+                            app_url=settings.app_url,
+                            challenge_id=challenge_id,
+                        )
+            session.commit()
+        except Exception as e:
+            sentry_sdk.capture_exception(e)

--- a/backend/app/services/email.py
+++ b/backend/app/services/email.py
@@ -1,0 +1,166 @@
+"""Transactional email service via Resend."""
+
+import logging
+
+import httpx
+
+from app.config import settings
+
+logger = logging.getLogger(__name__)
+
+FROM_ADDRESS = "Greenlight <notifications@propelai.solutions>"
+
+
+def send_email(to: str | list[str], subject: str, html: str, text: str) -> bool:
+    """Send an email via Resend. Returns True on success."""
+    if not settings.resend_api_key:
+        logger.warning("RESEND_API_KEY not configured — skipping email")
+        return False
+    recipients = [to] if isinstance(to, str) else to
+    try:
+        resp = httpx.post(
+            "https://api.resend.com/emails",
+            headers={"Authorization": f"Bearer {settings.resend_api_key}"},
+            json={
+                "from": FROM_ADDRESS,
+                "to": recipients,
+                "subject": subject,
+                "html": html,
+                "text": text,
+            },
+        )
+        if resp.status_code != 200:
+            logger.error("Resend API returned %d: %s", resp.status_code, resp.text)
+            return False
+        return True
+    except Exception as e:
+        logger.error("Resend API call failed: %s", e)
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Email templates
+# ---------------------------------------------------------------------------
+
+_HEADER = """\
+<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"></head>
+<body style="margin:0;padding:0;background:#f9fafb;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;">
+<table width="100%" cellpadding="0" cellspacing="0" style="background:#f9fafb;padding:40px 0;">
+<tr><td align="center">
+<table width="480" cellpadding="0" cellspacing="0" style="background:#ffffff;border-radius:12px;overflow:hidden;box-shadow:0 1px 3px rgba(0,0,0,0.1);">
+<tr><td style="background:#059669;padding:24px 32px;">
+  <span style="color:#ffffff;font-size:20px;font-weight:700;">Greenlight</span>
+</td></tr>"""
+
+_FOOTER = """\
+<tr><td style="padding:16px 32px;border-top:1px solid #e5e7eb;">
+  <p style="margin:0;color:#9ca3af;font-size:12px;">This is an automated notification from Greenlight.</p>
+</td></tr>
+</table>
+</td></tr></table>
+</body></html>"""
+
+
+def _wrap(body_html: str) -> str:
+    return f"{_HEADER}{body_html}{_FOOTER}"
+
+
+# --- Waitlist signup notification (to founder) ---
+
+def send_waitlist_notification(name: str, email: str, created_at_str: str):
+    """Notify the founder about a new waitlist signup."""
+    if not settings.notify_email:
+        return
+    html = _wrap(f"""\
+<tr><td style="padding:32px;">
+  <h1 style="margin:0 0 8px;font-size:22px;color:#111827;">New Waitlist Signup</h1>
+  <p style="margin:0 0 24px;color:#6b7280;font-size:14px;">Someone just joined the Greenlight waitlist.</p>
+  <table width="100%" cellpadding="0" cellspacing="0" style="background:#f9fafb;border-radius:8px;">
+    <tr><td style="padding:8px 20px;">
+      <span style="color:#6b7280;font-size:12px;text-transform:uppercase;letter-spacing:0.05em;">Name</span><br/>
+      <span style="color:#111827;font-size:16px;font-weight:600;">{name}</span>
+    </td></tr>
+    <tr><td style="padding:8px 20px;">
+      <span style="color:#6b7280;font-size:12px;text-transform:uppercase;letter-spacing:0.05em;">Email</span><br/>
+      <a href="mailto:{email}" style="color:#059669;font-size:16px;font-weight:600;text-decoration:none;">{email}</a>
+    </td></tr>
+    <tr><td style="padding:8px 20px;">
+      <span style="color:#6b7280;font-size:12px;text-transform:uppercase;letter-spacing:0.05em;">Signed up</span><br/>
+      <span style="color:#111827;font-size:14px;">{created_at_str}</span>
+    </td></tr>
+  </table>
+</td></tr>""")
+    text = f"New waitlist signup!\n\nName: {name}\nEmail: {email}\nSigned up: {created_at_str}"
+    send_email(settings.notify_email, f"New waitlist signup: {name}", html, text)
+
+
+# --- Team invite email (to invitee) ---
+
+def send_team_invite_email(
+    to_email: str,
+    inviter_name: str,
+    team_name: str,
+    app_url: str,
+):
+    """Send a team invitation email to a new user."""
+    html = _wrap(f"""\
+<tr><td style="padding:32px;">
+  <h1 style="margin:0 0 8px;font-size:22px;color:#111827;">You're Invited!</h1>
+  <p style="margin:0 0 24px;color:#6b7280;font-size:15px;">
+    <strong>{inviter_name}</strong> invited you to join the team
+    <strong>{team_name or "their team"}</strong> on Greenlight.
+  </p>
+  <p style="margin:0 0 24px;color:#6b7280;font-size:14px;">
+    Greenlight helps teams brainstorm ideas and get AI-powered analysis —
+    so everyone's voice is heard.
+  </p>
+  <table cellpadding="0" cellspacing="0">
+    <tr><td style="background:#059669;border-radius:8px;padding:12px 28px;">
+      <a href="{app_url}" style="color:#ffffff;font-size:15px;font-weight:600;text-decoration:none;">
+        Join the team
+      </a>
+    </td></tr>
+  </table>
+</td></tr>""")
+    text = (
+        f"{inviter_name} invited you to join {team_name or 'their team'} on Greenlight.\n\n"
+        f"Sign up here: {app_url}"
+    )
+    send_email(to_email, f"{inviter_name} invited you to Greenlight", html, text)
+
+
+# --- Analysis complete email (to all collaborators) ---
+
+def send_analysis_complete_email(
+    to_email: str,
+    user_name: str,
+    challenge_title: str,
+    app_url: str,
+    challenge_id: int,
+):
+    """Notify a collaborator that AI analysis is complete."""
+    analysis_url = f"{app_url}/challenges/{challenge_id}/analysis"
+    html = _wrap(f"""\
+<tr><td style="padding:32px;">
+  <h1 style="margin:0 0 8px;font-size:22px;color:#111827;">Analysis Complete!</h1>
+  <p style="margin:0 0 8px;color:#6b7280;font-size:15px;">Hi {user_name},</p>
+  <p style="margin:0 0 24px;color:#6b7280;font-size:15px;">
+    The AI analysis for <strong>{challenge_title}</strong> is ready.
+    Every idea has been evaluated for pros &amp; cons, feasibility, and impact.
+  </p>
+  <table cellpadding="0" cellspacing="0">
+    <tr><td style="background:#059669;border-radius:8px;padding:12px 28px;">
+      <a href="{analysis_url}" style="color:#ffffff;font-size:15px;font-weight:600;text-decoration:none;">
+        View Analysis
+      </a>
+    </td></tr>
+  </table>
+</td></tr>""")
+    text = (
+        f"Hi {user_name},\n\n"
+        f"AI analysis for \"{challenge_title}\" is complete.\n\n"
+        f"View it here: {analysis_url}"
+    )
+    send_email(to_email, f"Analysis ready: {challenge_title}", html, text)

--- a/backend/app/services/notifications.py
+++ b/backend/app/services/notifications.py
@@ -1,0 +1,57 @@
+"""Create in-app notifications for collaborators."""
+
+import logging
+
+from sqlmodel import Session, select
+
+from app.models.notification import Notification, NotificationType
+from app.models.problem import ChallengeCollaborator
+from app.models.user import User
+
+logger = logging.getLogger(__name__)
+
+
+def notify_collaborators(
+    session: Session,
+    challenge_id: int,
+    sender_id: int,
+    notification_type: NotificationType,
+    title: str,
+    body: str,
+):
+    """Create a notification for every collaborator except the sender."""
+    collabs = session.exec(
+        select(ChallengeCollaborator).where(
+            ChallengeCollaborator.challenge_id == challenge_id
+        )
+    ).all()
+    for collab in collabs:
+        if collab.user_id == sender_id:
+            continue
+        session.add(Notification(
+            user_id=collab.user_id,
+            type=notification_type,
+            title=title,
+            body=body,
+            challenge_id=challenge_id,
+        ))
+    session.commit()
+
+
+def notify_user(
+    session: Session,
+    user_id: int,
+    notification_type: NotificationType,
+    title: str,
+    body: str,
+    challenge_id: int | None = None,
+):
+    """Create a notification for a single user."""
+    session.add(Notification(
+        user_id=user_id,
+        type=notification_type,
+        title=title,
+        body=body,
+        challenge_id=challenge_id,
+    ))
+    session.commit()

--- a/backend/tests/test_email_service.py
+++ b/backend/tests/test_email_service.py
@@ -1,0 +1,99 @@
+"""Tests for the email service with mocked Resend API."""
+
+from unittest.mock import patch, MagicMock
+
+from app.services.email import (
+    send_email,
+    send_waitlist_notification,
+    send_team_invite_email,
+    send_analysis_complete_email,
+)
+
+
+def test_send_email_no_api_key():
+    with patch("app.services.email.settings") as mock_settings:
+        mock_settings.resend_api_key = ""
+        result = send_email("test@test.com", "Subject", "<h1>Hi</h1>", "Hi")
+    assert result is False
+
+
+def test_send_email_success():
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+
+    with patch("app.services.email.settings") as mock_settings, \
+         patch("app.services.email.httpx.post", return_value=mock_resp):
+        mock_settings.resend_api_key = "re_test"
+        result = send_email("test@test.com", "Subject", "<h1>Hi</h1>", "Hi")
+    assert result is True
+
+
+def test_send_email_api_error():
+    mock_resp = MagicMock()
+    mock_resp.status_code = 422
+    mock_resp.text = "Invalid"
+
+    with patch("app.services.email.settings") as mock_settings, \
+         patch("app.services.email.httpx.post", return_value=mock_resp):
+        mock_settings.resend_api_key = "re_test"
+        result = send_email("test@test.com", "Subject", "<h1>Hi</h1>", "Hi")
+    assert result is False
+
+
+def test_send_email_exception():
+    with patch("app.services.email.settings") as mock_settings, \
+         patch("app.services.email.httpx.post", side_effect=Exception("Network error")):
+        mock_settings.resend_api_key = "re_test"
+        result = send_email("test@test.com", "Subject", "<h1>Hi</h1>", "Hi")
+    assert result is False
+
+
+def test_send_email_list_recipients():
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+
+    with patch("app.services.email.settings") as mock_settings, \
+         patch("app.services.email.httpx.post", return_value=mock_resp) as mock_post:
+        mock_settings.resend_api_key = "re_test"
+        send_email(["a@test.com", "b@test.com"], "Subject", "<h1>Hi</h1>", "Hi")
+    # Verify the list was passed through
+    call_json = mock_post.call_args.kwargs["json"]
+    assert call_json["to"] == ["a@test.com", "b@test.com"]
+
+
+def test_send_waitlist_notification():
+    with patch("app.services.email.settings") as mock_settings, \
+         patch("app.services.email.send_email") as mock_send:
+        mock_settings.notify_email = "admin@test.com"
+        send_waitlist_notification("Test User", "test@test.com", "March 2, 2026")
+    mock_send.assert_called_once()
+    args = mock_send.call_args
+    assert "admin@test.com" in args[0]
+    assert "Test User" in args[0][1]
+
+
+def test_send_waitlist_notification_no_notify_email():
+    with patch("app.services.email.settings") as mock_settings, \
+         patch("app.services.email.send_email") as mock_send:
+        mock_settings.notify_email = ""
+        send_waitlist_notification("Test", "t@t.com", "now")
+    mock_send.assert_not_called()
+
+
+def test_send_team_invite_email():
+    with patch("app.services.email.send_email") as mock_send:
+        send_team_invite_email("new@test.com", "Alice", "Family Team", "http://localhost")
+    mock_send.assert_called_once()
+    args = mock_send.call_args[0]
+    assert args[0] == "new@test.com"
+    assert "Alice" in args[1]
+
+
+def test_send_analysis_complete_email():
+    with patch("app.services.email.send_email") as mock_send:
+        send_analysis_complete_email("user@test.com", "Bob", "Bedtime Routine", "http://localhost", 42)
+    mock_send.assert_called_once()
+    args = mock_send.call_args[0]
+    assert args[0] == "user@test.com"
+    assert "Bedtime Routine" in args[1]
+    assert "/challenges/42/analysis" in args[2]  # html contains the link

--- a/backend/tests/test_notifications.py
+++ b/backend/tests/test_notifications.py
@@ -1,0 +1,133 @@
+from app.models.notification import Notification, NotificationType
+
+
+def test_list_notifications_empty(client_a, session, user_a):
+    res = client_a.get("/api/notifications")
+    assert res.status_code == 200
+    assert res.json() == []
+
+
+def test_list_notifications(client_a, session, user_a):
+    session.add(Notification(
+        user_id=user_a.id,
+        type=NotificationType.idea_added,
+        title="New idea",
+        body="Someone added an idea",
+        challenge_id=1,
+    ))
+    session.commit()
+
+    res = client_a.get("/api/notifications")
+    assert res.status_code == 200
+    data = res.json()
+    assert len(data) == 1
+    assert data[0]["title"] == "New idea"
+    assert data[0]["read"] is False
+
+
+def test_unread_count(client_a, session, user_a):
+    session.add(Notification(
+        user_id=user_a.id, type=NotificationType.idea_added,
+        title="T", body="B",
+    ))
+    session.add(Notification(
+        user_id=user_a.id, type=NotificationType.comment_added,
+        title="T2", body="B2", read=True,
+    ))
+    session.commit()
+
+    res = client_a.get("/api/notifications/unread-count")
+    assert res.status_code == 200
+    assert res.json()["count"] == 1
+
+
+def test_mark_read(client_a, session, user_a):
+    notif = Notification(
+        user_id=user_a.id, type=NotificationType.idea_added,
+        title="T", body="B",
+    )
+    session.add(notif)
+    session.commit()
+    session.refresh(notif)
+
+    res = client_a.post(f"/api/notifications/{notif.id}/read")
+    assert res.status_code == 200
+
+    res = client_a.get("/api/notifications/unread-count")
+    assert res.json()["count"] == 0
+
+
+def test_mark_read_not_found(client_a, session, user_a):
+    res = client_a.post("/api/notifications/99999/read")
+    assert res.status_code == 404
+
+
+def test_mark_read_other_user(client_a, session, user_a, user_b):
+    notif = Notification(
+        user_id=user_b.id, type=NotificationType.idea_added,
+        title="T", body="B",
+    )
+    session.add(notif)
+    session.commit()
+    session.refresh(notif)
+
+    res = client_a.post(f"/api/notifications/{notif.id}/read")
+    assert res.status_code == 404
+
+
+def test_mark_all_read(client_a, session, user_a):
+    for i in range(3):
+        session.add(Notification(
+            user_id=user_a.id, type=NotificationType.idea_added,
+            title=f"T{i}", body=f"B{i}",
+        ))
+    session.commit()
+
+    res = client_a.post("/api/notifications/read-all")
+    assert res.status_code == 200
+    assert "3" in res.json()["message"]
+
+    res = client_a.get("/api/notifications/unread-count")
+    assert res.json()["count"] == 0
+
+
+def test_idea_creates_notification(client_a, client_b, session, user_a, user_b):
+    """Creating an idea should notify other collaborators."""
+    from app.models.problem import Challenge, ChallengeCollaborator, CollaboratorRole
+    from app.models.session import GreenlightSession
+
+    c = Challenge(title="Notif Test", description="D", created_by=user_a.id)
+    session.add(c)
+    session.commit()
+    session.refresh(c)
+    session.add(ChallengeCollaborator(challenge_id=c.id, user_id=user_a.id, role=CollaboratorRole.owner))
+    session.add(ChallengeCollaborator(challenge_id=c.id, user_id=user_b.id, role=CollaboratorRole.collaborator))
+    session.add(GreenlightSession(challenge_id=c.id))
+    session.commit()
+
+    client_a.post(f"/api/challenges/{c.id}/ideas", json={"content": "My great idea"})
+
+    res = client_b.get("/api/notifications/unread-count")
+    assert res.json()["count"] == 1
+
+
+def test_comment_creates_notification(client_a, client_b, session, user_a, user_b):
+    """Creating a comment should notify other collaborators."""
+    from app.models.problem import Challenge, ChallengeCollaborator, CollaboratorRole
+    from app.models.idea import Idea
+
+    c = Challenge(title="Comment Notif", description="D", created_by=user_a.id)
+    session.add(c)
+    session.commit()
+    session.refresh(c)
+    session.add(ChallengeCollaborator(challenge_id=c.id, user_id=user_a.id, role=CollaboratorRole.owner))
+    session.add(ChallengeCollaborator(challenge_id=c.id, user_id=user_b.id, role=CollaboratorRole.collaborator))
+    idea = Idea(challenge_id=c.id, content="Idea", created_by=user_a.id)
+    session.add(idea)
+    session.commit()
+    session.refresh(idea)
+
+    client_b.post(f"/api/ideas/{idea.id}/comments", json={"content": "Nice idea!"})
+
+    res = client_a.get("/api/notifications/unread-count")
+    assert res.json()["count"] == 1

--- a/frontend/src/components/NotificationBell.tsx
+++ b/frontend/src/components/NotificationBell.tsx
@@ -1,0 +1,138 @@
+import { useEffect, useState, useRef } from 'react';
+import { useNavigate } from 'react-router-dom';
+import api from '../api/client';
+import type { Notification } from '../types';
+
+export default function NotificationBell() {
+  const [notifications, setNotifications] = useState<Notification[]>([]);
+  const [unreadCount, setUnreadCount] = useState(0);
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+  const navigate = useNavigate();
+
+  const fetchNotifications = async () => {
+    try {
+      const [notifRes, countRes] = await Promise.all([
+        api.get('/notifications'),
+        api.get('/notifications/unread-count'),
+      ]);
+      setNotifications(notifRes.data);
+      setUnreadCount(countRes.data.count);
+    } catch {
+      // silently fail
+    }
+  };
+
+  useEffect(() => {
+    fetchNotifications();
+    const interval = setInterval(fetchNotifications, 30000);
+    return () => clearInterval(interval);
+  }, []);
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
+
+  const markAllRead = async () => {
+    await api.post('/notifications/read-all');
+    setUnreadCount(0);
+    setNotifications(prev => prev.map(n => ({ ...n, read: true })));
+  };
+
+  const handleClick = async (notif: Notification) => {
+    if (!notif.read) {
+      await api.post(`/notifications/${notif.id}/read`);
+      setUnreadCount(prev => Math.max(0, prev - 1));
+      setNotifications(prev =>
+        prev.map(n => (n.id === notif.id ? { ...n, read: true } : n))
+      );
+    }
+    setOpen(false);
+    if (notif.challenge_id) {
+      if (notif.type === 'analysis_complete') {
+        navigate(`/challenges/${notif.challenge_id}/analysis`);
+      } else {
+        navigate(`/challenges/${notif.challenge_id}`);
+      }
+    }
+  };
+
+  const timeAgo = (dateStr: string) => {
+    const diff = Date.now() - new Date(dateStr).getTime();
+    const mins = Math.floor(diff / 60000);
+    if (mins < 1) return 'just now';
+    if (mins < 60) return `${mins}m ago`;
+    const hours = Math.floor(mins / 60);
+    if (hours < 24) return `${hours}h ago`;
+    return `${Math.floor(hours / 24)}d ago`;
+  };
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        onClick={() => setOpen(!open)}
+        className="relative p-2 text-slate-400 hover:text-white transition-colors rounded-lg hover:bg-slate-800"
+      >
+        <svg className="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+          <path strokeLinecap="round" strokeLinejoin="round" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" />
+        </svg>
+        {unreadCount > 0 && (
+          <span className="absolute -top-0.5 -right-0.5 flex h-4 min-w-[16px] items-center justify-center rounded-full bg-emerald-500 px-1 text-[10px] font-bold text-white">
+            {unreadCount > 9 ? '9+' : unreadCount}
+          </span>
+        )}
+      </button>
+
+      {open && (
+        <div className="absolute right-0 top-full mt-2 w-80 bg-white rounded-xl shadow-xl border border-slate-200 z-50 overflow-hidden">
+          <div className="flex items-center justify-between px-4 py-3 border-b border-slate-100">
+            <span className="text-sm font-semibold text-slate-900">Notifications</span>
+            {unreadCount > 0 && (
+              <button
+                onClick={markAllRead}
+                className="text-xs text-emerald-600 hover:text-emerald-700 font-medium"
+              >
+                Mark all read
+              </button>
+            )}
+          </div>
+
+          <div className="max-h-80 overflow-y-auto">
+            {notifications.length === 0 ? (
+              <div className="px-4 py-8 text-center text-sm text-slate-400">
+                No notifications yet
+              </div>
+            ) : (
+              notifications.map(notif => (
+                <button
+                  key={notif.id}
+                  onClick={() => handleClick(notif)}
+                  className={`w-full text-left px-4 py-3 hover:bg-slate-50 transition-colors border-b border-slate-50 last:border-0 ${
+                    !notif.read ? 'bg-emerald-50/50' : ''
+                  }`}
+                >
+                  <div className="flex items-start gap-2">
+                    {!notif.read && (
+                      <span className="mt-1.5 h-2 w-2 shrink-0 rounded-full bg-emerald-500" />
+                    )}
+                    <div className={!notif.read ? '' : 'ml-4'}>
+                      <p className="text-sm font-medium text-slate-900">{notif.title}</p>
+                      <p className="text-xs text-slate-500 mt-0.5 line-clamp-2">{notif.body}</p>
+                      <p className="text-xs text-slate-400 mt-1">{timeAgo(notif.created_at)}</p>
+                    </div>
+                  </div>
+                </button>
+              ))
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -7,6 +7,7 @@ import CreateChallengeModal from '../components/CreateChallengeModal';
 import TeamSetup from '../components/TeamSetup';
 import TeamSettingsModal from '../components/TeamSettingsModal';
 import WelcomePage from './WelcomePage';
+import NotificationBell from '../components/NotificationBell';
 
 interface Props {
   user: User;
@@ -92,6 +93,7 @@ export default function DashboardPage({ user, onDevSignOut }: Props) {
                 </div>
               </button>
             )}
+            <NotificationBell />
             <span className="hidden sm:inline text-sm text-slate-300">{user.name}</span>
             {onDevSignOut ? (
               <button

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -114,3 +114,15 @@ export interface Team {
   name: string;
   members: TeamMember[];
 }
+
+export type NotificationType = 'idea_added' | 'comment_added' | 'approval_changed' | 'analysis_complete' | 'team_invite';
+
+export interface Notification {
+  id: number;
+  type: NotificationType;
+  title: string;
+  body: string;
+  challenge_id: number | null;
+  read: boolean;
+  created_at: string;
+}


### PR DESCRIPTION
## Summary
- **Email service** via Resend with 3 HTML templates: waitlist signup notification, team invite, analysis complete
- **In-app notifications** with Notification model, REST endpoints, and frontend bell component
- **Notification triggers** on: idea creation, comments, session approvals, analysis completion
- **Frontend**: NotificationBell in dashboard header with unread badge, click-to-navigate, mark-all-read
- 18 new tests (107 total, all passing)

Closes #16, closes #2

## New endpoints
- `GET /api/notifications` — list user's notifications (newest first, limit 50)
- `GET /api/notifications/unread-count` — unread badge count
- `POST /api/notifications/{id}/read` — mark single as read
- `POST /api/notifications/read-all` — mark all as read

## Config additions
- `RESEND_API_KEY` — Resend API key for sending emails
- `NOTIFY_EMAIL` — founder email for waitlist signup alerts

## Test plan
- [x] 107 tests pass (`uv run pytest tests/ -v`)
- [x] Email service tested with mocked Resend API (success, error, no key)
- [x] Notification CRUD tested (list, count, mark read, mark all read)
- [x] Idea + comment creation triggers notifications for collaborators
- [x] Frontend NotificationBell renders with dropdown and navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a transactional email service and in-app notification system, wiring them into key collaboration events and exposing them via backend APIs and a frontend notification UI.

New Features:
- Introduce a Resend-backed email service with templates for waitlist signups, team invites, and analysis completion notifications.
- Add a Notification model and REST API for listing, counting unread, and marking notifications as read or read-all.
- Add a NotificationBell component to the dashboard header that surfaces unread counts and navigable notifications for users.

Enhancements:
- Trigger collaborator notifications and emails when ideas are created, comments are added, sessions are approved, and analyses complete.
- Extend configuration to include Resend API credentials and a founder notification email address.

Tests:
- Add backend tests covering notification CRUD behavior and collaborator notification triggers for ideas and comments.
- Add backend tests for the email service, including success, failure, and configuration edge cases.