### PR TITLE
Add real-time updates via Server-Sent Events

### DIFF
--- a/backend/app/routers/challenges.py
+++ b/backend/app/routers/challenges.py
@@ -1,4 +1,5 @@
 from fastapi import APIRouter, HTTPException, status
+from fastapi.responses import StreamingResponse
 from sqlmodel import select
 
 from app.database import SessionDep
@@ -180,6 +181,30 @@ def update_challenge(
         created_at=challenge.created_at,
         idea_count=idea_count,
         session_status=gs.status if gs else None,
+    )
+
+
+@router.get("/{challenge_id}/events")
+async def challenge_events(challenge_id: int, session: SessionDep, current_user: CurrentUser):
+    """SSE stream of real-time updates for a challenge."""
+    collab = session.exec(
+        select(ChallengeCollaborator).where(
+            ChallengeCollaborator.challenge_id == challenge_id,
+            ChallengeCollaborator.user_id == current_user.id,
+        )
+    ).first()
+    if not collab:
+        raise HTTPException(status_code=403, detail="Not a collaborator")
+
+    from app.services.sse import subscribe
+    return StreamingResponse(
+        subscribe(challenge_id),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        },
     )
 
 

--- a/backend/app/routers/comments.py
+++ b/backend/app/routers/comments.py
@@ -84,4 +84,7 @@ def create_comment(
         preview,
     )
 
+    from app.services.sse import broadcast
+    broadcast(idea.challenge_id, "comment_added", {"idea_id": idea_id})
+
     return _enrich_comment(comment, session)

--- a/backend/app/routers/ideas.py
+++ b/backend/app/routers/ideas.py
@@ -75,6 +75,9 @@ def create_idea(
         preview,
     )
 
+    from app.services.sse import broadcast
+    broadcast(challenge_id, "idea_added", {"idea_id": idea.id})
+
     return _enrich_idea(idea, session)
 
 
@@ -105,6 +108,10 @@ def update_idea(
     session.add(idea)
     session.commit()
     session.refresh(idea)
+
+    from app.services.sse import broadcast
+    broadcast(idea.challenge_id, "idea_updated", {"idea_id": idea.id})
+
     return _enrich_idea(idea, session)
 
 
@@ -124,6 +131,11 @@ def delete_idea(idea_id: int, session: SessionDep, current_user: CurrentUser):
     ).all():
         session.delete(draft)
 
+    challenge_id = idea.challenge_id
     session.delete(idea)
     session.commit()
+
+    from app.services.sse import broadcast
+    broadcast(challenge_id, "idea_deleted", {"idea_id": idea_id})
+
     return {"message": "Idea deleted"}

--- a/backend/app/routers/sessions.py
+++ b/backend/app/routers/sessions.py
@@ -175,4 +175,7 @@ def approve_session(
             from app.services.analysis_runner import run_analysis
             background_tasks.add_task(run_analysis, challenge_id)
 
+    from app.services.sse import broadcast
+    broadcast(challenge_id, "session_updated", {"status": gs.status.value})
+
     return _enrich_session(gs, session)

--- a/backend/app/services/analysis_runner.py
+++ b/backend/app/services/analysis_runner.py
@@ -83,6 +83,10 @@ async def _run_analysis_async(challenge_id: int):
         session.add(gs)
         session.commit()
 
+        # Broadcast real-time update
+        from app.services.sse import broadcast
+        broadcast(challenge_id, "analysis_complete")
+
         # Notify collaborators via email + in-app
         try:
             from app.config import settings

--- a/backend/app/services/sse.py
+++ b/backend/app/services/sse.py
@@ -1,0 +1,48 @@
+"""Server-Sent Events broadcast hub for real-time updates."""
+
+import asyncio
+import json
+import logging
+from collections import defaultdict
+
+logger = logging.getLogger(__name__)
+
+# Map of challenge_id -> set of asyncio.Queue
+_subscribers: dict[int, set[asyncio.Queue]] = defaultdict(set)
+
+
+def broadcast(challenge_id: int, event_type: str, data: dict | None = None):
+    """Push an event to all subscribers of a challenge.
+
+    Safe to call from sync code — fires and forgets into each subscriber's queue.
+    """
+    queues = _subscribers.get(challenge_id)
+    if not queues:
+        return
+    payload = json.dumps({"type": event_type, **(data or {})})
+    dead = []
+    for q in queues:
+        try:
+            q.put_nowait(payload)
+        except asyncio.QueueFull:
+            dead.append(q)
+    for q in dead:
+        queues.discard(q)
+
+
+async def subscribe(challenge_id: int):
+    """Async generator that yields SSE-formatted strings."""
+    queue: asyncio.Queue = asyncio.Queue(maxsize=64)
+    _subscribers[challenge_id].add(queue)
+    try:
+        while True:
+            try:
+                payload = await asyncio.wait_for(queue.get(), timeout=30)
+                yield f"data: {payload}\n\n"
+            except asyncio.TimeoutError:
+                # Send keepalive
+                yield ": keepalive\n\n"
+    finally:
+        _subscribers[challenge_id].discard(queue)
+        if not _subscribers[challenge_id]:
+            del _subscribers[challenge_id]

--- a/frontend/src/hooks/useChallengeEvents.ts
+++ b/frontend/src/hooks/useChallengeEvents.ts
@@ -1,0 +1,70 @@
+import { useEffect, useRef } from 'react';
+import { useAuth } from '@clerk/clerk-react';
+
+interface ChallengeEvent {
+  type: string;
+  [key: string]: unknown;
+}
+
+/**
+ * Subscribe to real-time SSE events for a challenge.
+ * Calls onEvent whenever the server pushes an update.
+ */
+export function useChallengeEvents(
+  challengeId: number | undefined,
+  onEvent: (event: ChallengeEvent) => void,
+) {
+  const { getToken } = useAuth();
+  const onEventRef = useRef(onEvent);
+  onEventRef.current = onEvent;
+
+  useEffect(() => {
+    if (!challengeId) return;
+
+    let eventSource: EventSource | null = null;
+    let cancelled = false;
+
+    async function connect() {
+      const token = await getToken();
+      if (cancelled || !token) return;
+
+      // EventSource doesn't support custom headers, so pass token as query param
+      // Backend will need to accept this — but for now we use a fetch-based approach
+      const response = await fetch(`/api/challenges/${challengeId}/events`, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+
+      if (cancelled || !response.body) return;
+
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = '';
+
+      while (!cancelled) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split('\n');
+        buffer = lines.pop() || '';
+
+        for (const line of lines) {
+          if (line.startsWith('data: ')) {
+            try {
+              const data = JSON.parse(line.slice(6));
+              onEventRef.current(data);
+            } catch {
+              // ignore parse errors
+            }
+          }
+        }
+      }
+    }
+
+    connect();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [challengeId, getToken]);
+}

--- a/frontend/src/pages/AnalysisPage.tsx
+++ b/frontend/src/pages/AnalysisPage.tsx
@@ -4,6 +4,7 @@ import api from '../api/client';
 import type { Challenge, Idea, GreenlightSession, Analysis } from '../types';
 import AnalysisPanel from '../components/AnalysisPanel';
 import AnalysisProgress from '../components/AnalysisProgress';
+import { useChallengeEvents } from '../hooks/useChallengeEvents';
 
 interface Recommendation {
   idea: string;
@@ -34,6 +35,13 @@ export default function AnalysisPage() {
 
   const [reloadKey, setReloadKey] = useState(0);
   const reload = () => setReloadKey((k) => k + 1);
+
+  // Auto-refresh when analysis completes via SSE
+  useChallengeEvents(id ? Number(id) : undefined, (event) => {
+    if (event.type === 'analysis_complete' || event.type === 'session_updated') {
+      reload();
+    }
+  });
 
   useEffect(() => {
     async function load() {

--- a/frontend/src/pages/ChallengeDetailPage.tsx
+++ b/frontend/src/pages/ChallengeDetailPage.tsx
@@ -7,6 +7,7 @@ import IdeaCard from '../components/IdeaCard';
 import AddIdeaForm from '../components/AddIdeaForm';
 import SessionStatusBar from '../components/SessionStatusBar';
 import AISuggestButton from '../components/AISuggestButton';
+import { useChallengeEvents } from '../hooks/useChallengeEvents';
 
 interface Props {
   user: User;
@@ -36,6 +37,16 @@ export default function ChallengeDetailPage({ user }: Props) {
   useEffect(() => {
     fetchAll();
   }, [fetchAll]);
+
+  // Real-time updates via SSE
+  useChallengeEvents(id ? Number(id) : undefined, (event) => {
+    if (event.type === 'analysis_complete') {
+      navigate(`/challenges/${id}/analysis`);
+    } else {
+      // Re-fetch data for any other event (ideas, comments, approvals)
+      fetchAll();
+    }
+  });
 
   const handleApprove = async () => {
     setApproving(true);


### PR DESCRIPTION
## Summary
- SSE broadcast hub with per-challenge subscriber queues and 30s keepalive
- SSE endpoint GET /api/challenges/{id}/events (authenticated, streaming)
- Broadcast triggers on idea CRUD, comments, session approvals, analysis completion
- Frontend useChallengeEvents hook with auto-refresh on ChallengeDetailPage and AnalysisPage

Closes #3

## Test plan
- [x] 107 backend tests pass
- [x] SSE endpoint requires auth (403 for non-collaborators)
- [x] Broadcasts are non-blocking
- [x] Keepalive prevents connection timeout

Generated with Claude Code

## Summary by Sourcery

Add server-sent events support to deliver real-time challenge updates across backend and frontend.

New Features:
- Expose an authenticated SSE endpoint for streaming challenge-specific events to collaborators.
- Introduce a frontend hook to subscribe to challenge events and react to real-time updates on key pages.

Enhancements:
- Emit real-time broadcast events from idea, comment, session, and analysis flows to keep challenge views in sync.